### PR TITLE
[#16] Fixes to packaging

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -173,6 +173,9 @@ ospackage {
     user 'root'
     fileMode = 0755
 
+    // Incompatible with older version
+    conflicts('tcg-rim-tool')
+
     into('/opt/rimtool/lib') {
         from jar.outputs.files
         from configurations.runtimeClasspath
@@ -196,7 +199,7 @@ ospackage {
         }
     }
     into('/opt/rimtool/data') {
-        from('src/test/resources/') {
+        from('data') {
         }
     }
     link("/usr/local/bin/rim", "/opt/rimtool/scripts/rimtool.sh", 0x755)


### PR DESCRIPTION
This issue addresses the following:
1. Make the `rim-tool` package incompatible with previous `tcg-rim-tool` (via package conflict) due to shared folder structures.
2. Fixes issue where packaging is not copying over `data` folder to package directory.

Closes #16.