### PR TITLE
PC Client RIM quick start script for Linux

### DIFF
--- a/scripts/quick_pcrim.sh
+++ b/scripts/quick_pcrim.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+
+##############################################################################################
+#
+# quick_pcrim.sh 
+#    
+# Makes a test PC Client RIM Bundle.
+#
+############################################################################################
+
+DATA_OUT_DIR="/opt/rimtool/data/local"
+DATA_IN_DIR=""
+TPM_EVENT_LOG="binary_bios_measurements";
+DEFAULT_SRIM="/sys/kernel/security/tpm0/$TPM_EVENT_LOG"
+RIM_CONF="rim_fields.json"
+ORIG_CONFIG_FILE="../pcrim/rim_fields.json"
+USE_RM_FILE=NO
+RIM_TAG=$(uuidgen)
+# Certificate params
+RIM_CERT="BaseRIMTestCA.example.com.pem"
+SIG_ALG="rsa:2048"
+DAYS_VALID="3652"
+SUBJECT_DN="/C=US/O=example.com/OU=PC_RIM_Test"
+RIM_KEY="key.pem"
+
+check_admin () {
+	if [ "$EUID" -ne 0 ]
+     then echo "Error: quick_prcrim.sh requires root privileges.  Please run as root" 
+     exit 1
+fi
+}
+
+help () {
+  echo "  Create a quick test for a PC Client Rim Bundle based upon your local device"
+  echo "  Syntax: sh aca_setup.sh [-h|--help|-l |--rimel]"
+  echo "  options:"
+  echo "     -l  | --rimel  Optional path to the PC Client support RIM file"
+  echo "     -h  | --help   Print this help"
+  echo
+}
+
+# Many files and function used require admin access, so check and exit if not provided 
+check_admin
+
+OEM="$(cat /sys/devices/virtual/dmi/id/sys_vendor)";
+OEM_NO_SPACES=$(cat /sys/devices/virtual/dmi/id/sys_vendor| tr -d '[:space:]');
+MODEL="$(cat /sys/devices/virtual/dmi/id/product_name)";
+MODEL_NO_SPACES=$(cat /sys/devices/virtual/dmi/id/product_name| tr -d '[:space:]');
+OEM_URL=$OEM_NO_SPACES.com
+SUPPORT_RIM=$OEM_NO_SPACES.$MODEL_NO_SPACES.1.rimel
+BASE_RIM=$OEM_NO_SPACES.$MODEL_NO_SPACES.1.swidtag
+
+mkdir -p $DATA_OUT_DIR
+chmod 777 $DATA_OUT_DIR
+pushd $DATA_OUT_DIR
+
+## Process parameters
+# Process parameters Argument handling 
+POSITIONAL_ARGS=()
+ORIGINAL_ARGS=("$@")
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    -l|--rimel)
+      USE_RIMEL_FILE=true
+      RIMEL_PATH=$@
+      shift # past argument
+      shift # past parameter
+      ;;
+    -h|--help)
+      help
+      exit 0
+      shift # past argument
+      ;;
+    -*|--*)
+      echo "aca_setup.sh: Unknown option $1"
+      help
+      exit 1
+      ;;
+    *)
+     POSITIONAL_ARGS+=("$1") # save positional arg
+     # shift # past argument
+     break
+      ;;
+  esac
+done
+
+# Step 1 Obtain the Support RIM file...
+if [ -z "$USE_SM_FILE" ]; then
+  echo "Using $DEFAULT_SRIM as the Support RIM file..."
+  cp $DEFAULT_SRIM $DATA_OUT_DIR/$SUPPORT_RIM
+  chmod 777 $DATA_OUT_DIR/$SRIM_FILE_NAME
+  else
+    echo "Using provided support RIM $RIMEL_PATH as the Support RIM file..."
+    echo "Storing $RIMEL_PATH as $SUPPORT_RIM for use as the Support RIM file..."
+    cp $RIMEL_PATH $DATA_OUT_DIR/$SUPPORT_RIM
+fi
+
+# Step 2: Obtain and modify a config file
+cp  $ORIG_CONFIG_FILE $DATA_OUT_DIR/$RIM_CONF
+# Update the config file with local mfg and model
+sed -i "s/Example.com/$OEM/g" $RIM_CONF;
+sed -i "s/ProductA/$MODEL/g" $RIM_CONF;
+sed -i "s/ExampleUrl/$OEM_URL/g" $RIM_CONF;
+ #update the tagid so the ACA will not reject the upload 
+jq --arg new_val "$RIM_TAG" '.SoftwareIdentity.tagId = $new_val' "$RIM_CONF" > temp.json && mv temp.json "$RIM_CONF"
+chmod 777 $RIM_CONF
+
+# Step 3, set up the keys/certs needed for Base RIM Creation
+echo "Creating a signing key for signing the Bse RIM"
+    $(openssl req -x509 -nodes -days "$DAYS_VALID" -newkey "$SIG_ALG" -keyout "$RIM_KEY" -out "$RIM_CERT" -subj "$SUBJECT_DN" >> /dev/null)
+    if [ $? -ne 0 ]; then
+        echo "Failed to create the key pair, exiting"
+        exit 1
+    fi
+chmod 777 $RIM_SIGN_CERT $SIG_KEY
+
+# Step 4 create the new PC CLient Base RIM file
+echo "Creating new Base RIM ..... "
+
+echo "rim create -r pcrim -c $RIM_CONF -k  $RIM_KEY -p $RIM_CERT -l $SUPPORT_RIM -o $BASE_RIM"
+/usr/local/bin/rim create -r pcrim -c $RIM_CONF -k  $RIM_KEY -p $RIM_CERT  -l $SUPPORT_RIM -o $BASE_RIM
+
+chmod 777 $BASE_RIM
+
+popd
+echo "Done."

--- a/scripts/quick_pcrim.sh
+++ b/scripts/quick_pcrim.sh
@@ -29,7 +29,6 @@ RIM_SIGNER_DN="/C=US/ST=MD/O=example.com/CN=Test_PC_RIM_SIGNER"
 RIM_SIGNER="RIM_Test_Signer"
 RIM_SIGNER_CERT="BaseRIMTestCA.example.com.pem"
 SIG_ALG="rsa:2048"
-DAYS_VALID="3652"
 SUBJECT_DN="/C=US/O=example.com/OU=PC_RIM_Test"
 RIM_KEY="key.pem"
 

--- a/scripts/quick_pcrim.sh
+++ b/scripts/quick_pcrim.sh
@@ -5,29 +5,60 @@
 # quick_pcrim.sh 
 #    
 # Makes a test PC Client RIM Bundle.
+#  Writes the test files to /opt/rimtool/data/local
 #
 ############################################################################################
 
 DATA_OUT_DIR="/opt/rimtool/data/local"
-DATA_IN_DIR=""
+#DATA_IN_DIR=""
 TPM_EVENT_LOG="binary_bios_measurements";
 DEFAULT_SRIM="/sys/kernel/security/tpm0/$TPM_EVENT_LOG"
 RIM_CONF="rim_fields.json"
-ORIG_CONFIG_FILE="../pcrim/rim_fields.json"
+ORIG_CONFIG_FILE="/opt/rimtool/data/pcrim/rim_fields.json"
 USE_RM_FILE=NO
 RIM_TAG=$(uuidgen)
+RIM_EXE="/usr/local/bin/rim"
+VERBOSE=false
+DAYS=365
+
+# PKI
+PKI_ROOT="RIM_Test_RSA_Root"
+PKI_ROOT_DN="/C=US/ST=MD/O=example.com/CN=Test_PC_RIM_RootCA"
+RIM_SIGNER_DN="/C=US/ST=MD/O=example.com/CN=Test_PC_RIM_SIGNER"
+
 # Certificate params
-RIM_CERT="BaseRIMTestCA.example.com.pem"
+RIM_SIGNER="RIM_Test_Signer"
+RIM_SIGNER_CERT="BaseRIMTestCA.example.com.pem"
 SIG_ALG="rsa:2048"
 DAYS_VALID="3652"
 SUBJECT_DN="/C=US/O=example.com/OU=PC_RIM_Test"
 RIM_KEY="key.pem"
 
 check_admin () {
-	if [ "$EUID" -ne 0 ]
-     then echo "Error: quick_prcrim.sh requires root privileges.  Please run as root" 
+	if [ "$EUID" -ne 0 ]; then
+     echo "Error: quick_prcrim.sh requires root privileges.  Please run as root" 
      exit 1
 fi
+}
+
+check_prereq () {
+	if [ ! -f ${RIM_EXE} ]; then 
+     echo "Error: Rim tool executable not found."
+     echo "Please install the RIM_Tool and try again." 
+     exit 1	
+	fi
+    if [ ! command -v openssl &> /dev/null ]; then 
+     echo "OpenSSL is not installed."
+     exit 1;
+    fi
+}
+
+check_error () {
+	if [ "$1" -ne 0 ]; then 
+		echo "Error: $2"
+		popd
+		exit 1;
+	fi
 }
 
 help () {
@@ -35,13 +66,16 @@ help () {
   echo "  Syntax: sh aca_setup.sh [-h|--help|-l |--rimel]"
   echo "  options:"
   echo "     -l  | --rimel  Optional path to the PC Client support RIM file"
+  echo "     -v  | --verbose  Verbose output"
   echo "     -h  | --help   Print this help"
   echo
 }
 
-# Many files and function used require admin access, so check and exit if not provided 
+# Many files and function used require admin access, so check and exit if not provided
 check_admin
-
+# Make sure RIM Tool and openssl are installed 
+check_prereq
+# Get require data for specific device (requires admin)
 OEM="$(cat /sys/devices/virtual/dmi/id/sys_vendor)";
 OEM_NO_SPACES=$(cat /sys/devices/virtual/dmi/id/sys_vendor| tr -d '[:space:]');
 MODEL="$(cat /sys/devices/virtual/dmi/id/product_name)";
@@ -50,9 +84,8 @@ OEM_URL=$OEM_NO_SPACES.com
 SUPPORT_RIM=$OEM_NO_SPACES.$MODEL_NO_SPACES.1.rimel
 BASE_RIM=$OEM_NO_SPACES.$MODEL_NO_SPACES.1.swidtag
 
-mkdir -p $DATA_OUT_DIR
-chmod 777 $DATA_OUT_DIR
-pushd $DATA_OUT_DIR
+mkdir -p ${DATA_OUT_DIR}
+chmod 777 ${DATA_OUT_DIR}
 
 ## Process parameters
 # Process parameters Argument handling 
@@ -65,6 +98,10 @@ while [[ $# -gt 0 ]]; do
       RIMEL_PATH=$@
       shift # past argument
       shift # past parameter
+      ;;
+    -v|--verbose)
+      VERBOSE=true
+      shift # past argument
       ;;
     -h|--help)
       help
@@ -84,43 +121,80 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+pushd ${DATA_OUT_DIR} > /dev/null
+# Remove existing RIM file if they exist
+rm -f ${BASE_RIM}
+rm -f ${SUPPORT_RIM}
+
 # Step 1 Obtain the Support RIM file...
-if [ -z "$USE_SM_FILE" ]; then
-  echo "Using $DEFAULT_SRIM as the Support RIM file..."
-  cp $DEFAULT_SRIM $DATA_OUT_DIR/$SUPPORT_RIM
-  chmod 777 $DATA_OUT_DIR/$SRIM_FILE_NAME
+if [ -z "${USE_SM_FILE}" ]; then
+  echo "Using ${DEFAULT_SRIM} as the Support RIM file..."
+  cp ${DEFAULT_SRIM} ${DATA_OUT_DIR}/${SUPPORT_RIM}
+  chmod 777 ${DATA_OUT_DIR}/${SRIM_FILE_NAME}
   else
-    echo "Using provided support RIM $RIMEL_PATH as the Support RIM file..."
-    echo "Storing $RIMEL_PATH as $SUPPORT_RIM for use as the Support RIM file..."
-    cp $RIMEL_PATH $DATA_OUT_DIR/$SUPPORT_RIM
+    echo "Using provided support RIM ${RIMEL_PATH} as the Support RIM file..."
+    echo "Storing ${RIMEL_PATH} as ${SUPPORT_RIM} for use as the Support RIM file..."
+    cp ${RIMEL_PATH} ${DATA_OUT_DIR}/${SUPPORT_RIM}
 fi
 
-# Step 2: Obtain and modify a config file
-cp  $ORIG_CONFIG_FILE $DATA_OUT_DIR/$RIM_CONF
+# Step 2: Obtain and modify a config file using OS provided parameters
+cp  ${ORIG_CONFIG_FILE} ${DATA_OUT_DIR}/${RIM_CONF}
 # Update the config file with local mfg and model
-sed -i "s/Example.com/$OEM/g" $RIM_CONF;
-sed -i "s/ProductA/$MODEL/g" $RIM_CONF;
-sed -i "s/ExampleUrl/$OEM_URL/g" $RIM_CONF;
- #update the tagid so the ACA will not reject the upload 
-jq --arg new_val "$RIM_TAG" '.SoftwareIdentity.tagId = $new_val' "$RIM_CONF" > temp.json && mv temp.json "$RIM_CONF"
-chmod 777 $RIM_CONF
+sed -i "s/Example.com/$OEM/g" ${RIM_CONF};
+sed -i "s/ProductA/$MODEL/g" ${RIM_CONF};
+sed -i "s/ExampleUrl/$OEM_URL/g" ${RIM_CONF};
+# Update the tagid so the ACA will not reject the upload if a RIM with the same tag exists 
+jq --arg new_val "${RIM_TAG}" '.SoftwareIdentity.tagId = $new_val' "${RIM_CONF}" > temp.json && mv temp.json "${RIM_CONF}"
+chmod 777 ${RIM_CONF}
 
 # Step 3, set up the keys/certs needed for Base RIM Creation
-echo "Creating a signing key for signing the Bse RIM"
-    $(openssl req -x509 -nodes -days "$DAYS_VALID" -newkey "$SIG_ALG" -keyout "$RIM_KEY" -out "$RIM_CERT" -subj "$SUBJECT_DN" >> /dev/null)
-    if [ $? -ne 0 ]; then
-        echo "Failed to create the key pair, exiting"
-        exit 1
-    fi
-chmod 777 $RIM_SIGN_CERT $SIG_KEY
 
-# Step 4 create the new PC CLient Base RIM file
+# Root CA
+if [ ! -f ${PKI_ROOT}.pem ]; then
+    echo "Generating RSA Root CA Certificate...."
+    openssl genrsa -out ${PKI_ROOT}.key
+    openssl req -new -x509 -nodes -sha256 -days ${DAYS} -key ${PKI_ROOT}.key -subj ${PKI_ROOT_DN} -out ${PKI_ROOT}.pem 
+    check_error $? "Generating Root CA Certificate"
+  else
+    echo "Using Exsiting Root Certificate ${PKI_ROOT}.pem "
+fi 
+
+if ${VERBOSE}; then openssl x509 -in ${PKI_ROOT}.pem -noout -text; fi;
+
+# RIM Signing Cert
+if [ ! -f ${RIM_SIGNER}.pem ]; then
+    echo "Generating RSA RIM Signing Certificate ...." 
+    openssl genrsa -out ${RIM_SIGNER}.key 3072 > /dev/null 2>&1
+    openssl req -new -key ${RIM_SIGNER}.key -sha256 -subj ${RIM_SIGNER_DN} -out ${RIM_SIGNER}.csr > /dev/null 2>&1
+    openssl x509 -req -in ${RIM_SIGNER}.csr -CA ${PKI_ROOT}.pem -CAkey ${PKI_ROOT}.key -CAcreateserial -days ${DAYS} -sha256 -out ${RIM_SIGNER}.pem > /dev/null 2>&1 
+    check_error $? "Generating RIM Signing Certificate"
+    rm ${RIM_SIGNER}.csr
+  else
+    echo "Using Exsiting Rim Signing Certificate ${RIM_SIGNER}.pem "  
+fi
+
+if ${VERBOSE}; then openssl x509 -in ${RIM_SIGNER}.pem -noout -text; fi;
+
+chmod 777 ${PKI_ROOT}.key ${PKI_ROOT}.pem
+
+# Step 4 create the new PC Client Base RIM file
 echo "Creating new Base RIM ..... "
 
-echo "rim create -r pcrim -c $RIM_CONF -k  $RIM_KEY -p $RIM_CERT -l $SUPPORT_RIM -o $BASE_RIM"
-/usr/local/bin/rim create -r pcrim -c $RIM_CONF -k  $RIM_KEY -p $RIM_CERT  -l $SUPPORT_RIM -o $BASE_RIM
+echo "rim create -r pcrim -c ${RIM_CONF} -k  ${RIM_SIGNER}.key -p ${RIM_SIGNER}.pem -l ${SUPPORT_RIM} -o ${BASE_RIM}"
+${RIM_EXE} create -r pcrim -c ${RIM_CONF} -k  ${RIM_SIGNER}.key -p ${RIM_SIGNER}.pem  -l ${SUPPORT_RIM} -o ${BASE_RIM}
+check_error $? "Generating Base RIM File ${BASE_RIM}"
 
-chmod 777 $BASE_RIM
+if ${VERBOSE}; then cat ${BASE_RIM}; fi;
 
-popd
+chmod 777 ${BASE_RIM}
+# Step 5 Verify the RIM
+
+${RIM_EXE} verify -r pcrim -p ${RIM_SIGNER}.pem   --in ${BASE_RIM}
+check_error $? "Verifying Base RIM File ${BASE_RIM}"
+
+if [[ $? -eq 0 ]]; then
+    echo "${BASE_RIM} and ${SUPPORT_RIM} can be found at ${DATA_OUT_DIR}"
+fi
+
+popd > /dev/null
 echo "Done."

--- a/scripts/quick_pcrim.sh
+++ b/scripts/quick_pcrim.sh
@@ -62,42 +62,31 @@ check_error () {
 }
 
 help () {
-  echo "  Create a quick test for a PC Client Rim Bundle based upon your local device"
-  echo "  Syntax: sh aca_setup.sh [-h|--help|-l |--rimel]"
+  echo "  Create a quick PC Client Rim Bundle based upon your local device"
+  echo "  Syntax: sh quick_pcrim.sh [-h|--help|-l |--rimel]"
   echo "  options:"
+  echo "     -h  | --help   Print this help"
   echo "     -l  | --rimel  Optional path to the PC Client support RIM file"
   echo "     -v  | --verbose  Verbose output"
-  echo "     -h  | --help   Print this help"
   echo
 }
-
-# Many files and function used require admin access, so check and exit if not provided
-check_admin
-# Make sure RIM Tool and openssl are installed 
-check_prereq
-# Get require data for specific device (requires admin)
-OEM="$(cat /sys/devices/virtual/dmi/id/sys_vendor)";
-OEM_NO_SPACES=$(cat /sys/devices/virtual/dmi/id/sys_vendor| tr -d '[:space:]');
-MODEL="$(cat /sys/devices/virtual/dmi/id/product_name)";
-MODEL_NO_SPACES=$(cat /sys/devices/virtual/dmi/id/product_name| tr -d '[:space:]');
-OEM_URL=$OEM_NO_SPACES.com
-SUPPORT_RIM=$OEM_NO_SPACES.$MODEL_NO_SPACES.1.rimel
-BASE_RIM=$OEM_NO_SPACES.$MODEL_NO_SPACES.1.swidtag
-
-mkdir -p ${DATA_OUT_DIR}
-chmod 777 ${DATA_OUT_DIR}
 
 ## Process parameters
 # Process parameters Argument handling 
 POSITIONAL_ARGS=()
-ORIGINAL_ARGS=("$@")
+#ORIGINAL_ARGS=("$@")
 while [[ $# -gt 0 ]]; do
   case $1 in
     -l|--rimel)
       USE_RIMEL_FILE=true
-      RIMEL_PATH=$@
       shift # past argument
-      shift # past parameter
+      RIMEL_PATH=$@
+      if [ -z ${RIMEL_PATH} ]; then
+          echo "Error: -l requires a file path";
+          exit 1;
+       else
+          shift # past parameter
+       fi
       ;;
     -v|--verbose)
       VERBOSE=true
@@ -121,21 +110,42 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+# Many files and function used require admin access, so check and exit if not provided
+check_admin
+# Make sure RIM Tool and openssl are installed 
+check_prereq
+# Get require data for specific device (requires admin)
+OEM="$(cat /sys/devices/virtual/dmi/id/sys_vendor)";
+OEM_NO_SPACES=$(cat /sys/devices/virtual/dmi/id/sys_vendor| tr -d '[:space:]');
+MODEL="$(cat /sys/devices/virtual/dmi/id/product_name)";
+MODEL_NO_SPACES=$(cat /sys/devices/virtual/dmi/id/product_name| tr -d '[:space:]');
+OEM_URL=$OEM_NO_SPACES.com
+SUPPORT_RIM=$OEM_NO_SPACES.$MODEL_NO_SPACES.1.rimel
+BASE_RIM=$OEM_NO_SPACES.$MODEL_NO_SPACES.1.swidtag
+
+mkdir -p ${DATA_OUT_DIR}
+chmod 777 ${DATA_OUT_DIR}
+
+
 pushd ${DATA_OUT_DIR} > /dev/null
 # Remove existing RIM file if they exist
 rm -f ${BASE_RIM}
 rm -f ${SUPPORT_RIM}
 
 # Step 1 Obtain the Support RIM file...
-if [ -z "${USE_SM_FILE}" ]; then
+if [ -z "${USE_RIMEL_FILE}" ]; then
   echo "Using ${DEFAULT_SRIM} as the Support RIM file..."
   cp ${DEFAULT_SRIM} ${DATA_OUT_DIR}/${SUPPORT_RIM}
-  chmod 777 ${DATA_OUT_DIR}/${SRIM_FILE_NAME}
   else
+    if [ ! -f ${RIMEL_PATH} ]; then
+      echo "Error: file ${RIMEL_PATH} for use with -l parameter does  not exist"
+      exit 1;
+    fi
     echo "Using provided support RIM ${RIMEL_PATH} as the Support RIM file..."
     echo "Storing ${RIMEL_PATH} as ${SUPPORT_RIM} for use as the Support RIM file..."
     cp ${RIMEL_PATH} ${DATA_OUT_DIR}/${SUPPORT_RIM}
 fi
+chmod 777 ${DATA_OUT_DIR}/${SUPPORT_RIM}
 
 # Step 2: Obtain and modify a config file using OS provided parameters
 cp  ${ORIG_CONFIG_FILE} ${DATA_OUT_DIR}/${RIM_CONF}

--- a/scripts/quick_pcrim.sh
+++ b/scripts/quick_pcrim.sh
@@ -190,8 +190,8 @@ chmod 777 ${PKI_ROOT}.key ${PKI_ROOT}.pem
 # Step 4 create the new PC Client Base RIM file
 echo "Creating new Base RIM ..... "
 
-echo "rim create -r pcrim -c ${RIM_CONF} -k  ${RIM_SIGNER}.key -p ${RIM_SIGNER}.pem -l ${SUPPORT_RIM} -o ${BASE_RIM}"
-${RIM_EXE} create -r pcrim -c ${RIM_CONF} -k  ${RIM_SIGNER}.key -p ${RIM_SIGNER}.pem  -l ${SUPPORT_RIM} -o ${BASE_RIM}
+echo "rim create -r pcrim -c ${RIM_CONF} -e -k ${RIM_SIGNER}.key -p ${RIM_SIGNER}.pem -l ${SUPPORT_RIM} -o ${BASE_RIM}"
+${RIM_EXE} create -r pcrim -c ${RIM_CONF} -e -k ${RIM_SIGNER}.key -p ${RIM_SIGNER}.pem -l ${SUPPORT_RIM} -o ${BASE_RIM}
 check_error $? "Generating Base RIM File ${BASE_RIM}"
 
 if ${VERBOSE}; then cat ${BASE_RIM}; fi;

--- a/scripts/quick_pcrim.sh
+++ b/scripts/quick_pcrim.sh
@@ -15,7 +15,6 @@ TPM_EVENT_LOG="binary_bios_measurements";
 DEFAULT_SRIM="/sys/kernel/security/tpm0/$TPM_EVENT_LOG"
 RIM_CONF="rim_fields.json"
 ORIG_CONFIG_FILE="/opt/rimtool/data/pcrim/rim_fields.json"
-USE_RM_FILE=NO
 RIM_TAG=$(uuidgen)
 RIM_EXE="/usr/local/bin/rim"
 VERBOSE=false
@@ -98,7 +97,7 @@ while [[ $# -gt 0 ]]; do
       shift # past argument
       ;;
     -*|--*)
-      echo "aca_setup.sh: Unknown option $1"
+      echo "quick_pcrim.sh: Unknown option $1"
       help
       exit 1
       ;;


### PR DESCRIPTION
Adds a script to the script folder that generates a PC Client RIM based upon the device its run from:
1. Checks that RIM_Tool and openssl are installed.
2. Pulls the last TPM Event Log and uses it as a Support RIM file.
3. Generates a Root Certificate and RIM Signer Certificate
4. Creates a json config file for the RIM_Tool using Manufacturer, Model, and SN of he current device.
5. Creates/Signs a PC Client base RIM

Notes:
* Requires RIM_Tool to be installed via rpm package
* Requires openssl to be installed
* -h option lsists optional parameters
* Requires admin privileges to run
* Uses /opt/rimtool/local as a working folder
* Will not overwrite CA or Signing cert if they already exist
* Only currently supports RSA 3072
* Base RIM and Support RIM are placed in the working folder 
* Supports a verbose mode
* Can use the -l parameter to supply custom support rim

Example use:
```
sudo quick_pcrim.sh -h
 
 Create a quick test for a PC Client Rim Bundle based upon your local device
  Syntax: sh aca_setup.sh [-h|--help|-l |--rimel]
  options:
    -h  | --help   Print this help
     -l  | --rimel  Optional path to the PC Client support RIM file
    -v  | --verbose  Verbose output 
```