### PR TITLE
[#44] Pretty-print formatting for PCRIMs

### DIFF
--- a/data/pcrim/laptop.default.1.swidtag
+++ b/data/pcrim/laptop.default.1.swidtag
@@ -1,42 +1,9 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<ns2:SoftwareIdentity xmlns:ns2="http://standards.iso.org/iso/19770/-2/2015/schema.xsd" xmlns:ns3="http://www.w3.org/2000/09/xmldsig#" corpus="false" name="TCG RIM example" patch="false" supplemental="false" tagId="ca366cd7-b1a6-4afa-a5b1-2d7ebd8d9c" tagVersion="1" version="0.1" versionScheme="multipartnumeric" xml:lang="en">
-  <ns2:Entity name="HIRS" regid="www.example.com" role="softwareCreator tagCreator"/>
-  <ns2:Link href="https://Example.com/support/ProductA/firmware/installfiles" rel="installationmedia"/>
-  <ns2:Meta xmlns:rim="https://trustedcomputinggroup.org/wp-content/uploads/TCG_RIM_Model" rim:bindingSpec="IOT RIM" rim:bindingSpecVersion="1.2" rim:platformManufacturerId="00201234" rim:platformManufacturerStr="Example.com" rim:platformModel="ProductA"/>
-  <ns2:Payload>
-    <ns2:Directory xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Test" xsi:type="ns2:Directory">
-      <ns2:File xmlns:SHA256="http://www.w3.org/2001/04/xmlenc#sha256" SHA256:hash="4479ca722623f8c47b703996ced3cbd981b06b1ae8a897db70137e0b7c546848" name="TpmLog.bin" size="7459" xsi:type="ns2:File"/>
-    </ns2:Directory>
-  </ns2:Payload>
-  <Signature xmlns="http://www.w3.org/2000/09/xmldsig#">
-    <SignedInfo>
-      <CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/>
-      <SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
-      <Reference URI="">
-        <Transforms>
-          <Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
-        </Transforms>
-        <DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
-        <DigestValue>TqJg3fUAc3G+dbKTM6WYGdOyeLv5mURXRG7dUdqScKI=</DigestValue>
-      </Reference>
-    </SignedInfo>
-    <SignatureValue>j6eeaoUkho33St4Ukc9gLUTKjroL1QcWLJoLnH+EbZ2mcXH/j+edh7HhvZYPwS1hGwt3HWPcToM5&#13;
-gVWODTaA7Ud3nyHdPkuOp3MMgushOg0cmb9KmV4JEXMrTAK9CSLf60zbpdVVwbIn57QGDP4aFXmr&#13;
-UDDebquKss6x0IAPAWw79/RAdRuEyu1gkt0nPg/mSH7DehH/pJAVTBVVJuFfjcg7gOx3j92LkOdE&#13;
-+z01StGBGtrirlpKPg+yu9cE5SGoYUyCts0Fi0gbLBOgJ9gr9lNO2KZZnwa9nyDmzP3Z5SkUd+ig&#13;
-qARtNfsDEXNCrnTLzTHnp+MyV/BHVQm/CFgEoQ==</SignatureValue>
-    <KeyInfo>
-      <KeyValue>
-        <RSAKeyValue>
-          <Modulus>p3WVYaRJG7EABjbAdqDYZXFSTV1nHY9Ol9A5+W8t5xwBXBryZCGWxERGr5AryKWPxd+qzjj+cFpx&#13;
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><ns2:SoftwareIdentity xmlns:ns2="http://standards.iso.org/iso/19770/-2/2015/schema.xsd" xmlns:ns3="http://www.w3.org/2000/09/xmldsig#" corpus="false" name="TCG RIM example" patch="false" supplemental="false" tagId="ca366cd7-b1a6-4afa-a5b1-2d7ebd8d9c" tagVersion="1" version="0.1" versionScheme="multipartnumeric" xml:lang="en"><ns2:Entity name="HIRS" regid="www.example.com" role="softwareCreator tagCreator"/><ns2:Link href="https://Example.com/support/ProductA/firmware/installfiles" rel="installationmedia"/><ns2:Meta xmlns:rim="https://trustedcomputinggroup.org/wp-content/uploads/TCG_RIM_Model" rim:bindingSpec="IOT RIM" rim:bindingSpecVersion="1.2" rim:platformManufacturerId="00201234" rim:platformManufacturerStr="Example.com" rim:platformModel="ProductA"/><ns2:Payload><ns2:Directory xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" location="data/pcrim/" name="" xsi:type="ns2:Directory"><ns2:File xmlns:SHA256="http://www.w3.org/2001/04/xmlenc#sha256" SHA256:hash="4479ca722623f8c47b703996ced3cbd981b06b1ae8a897db70137e0b7c546848" name="TpmLog.bin" size="7459" xsi:type="ns2:File"/></ns2:Directory></ns2:Payload><Signature xmlns="http://www.w3.org/2000/09/xmldsig#"><SignedInfo><CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/><SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/><Reference URI=""><Transforms><Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/></Transforms><DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/><DigestValue>6V6eJHMAbs0ywSEmfJ/n8yY1GCvAsZy8waeCrel9xE4=</DigestValue></Reference></SignedInfo><SignatureValue>DdBvwex+fRGW+omZNYrcHIHl2avnLs+YwbujA9bltjXQ5Atuhr2cMieT/U9rSaQwRa7NswoHJ0Jy&#13;
+P6x+CC/a1lrytsLHSwjubRVw/bXQUHGQfF2sfJ4C2NF/kbl9+aJWblZoQirLm9teScpkFt4D54cY&#13;
+nxxH5p5dtpikmZLF9wLeQDgggLD5sWVBophIVeoQRLHeTOHzY/lJX+A2uCYmBtW6m5rX0dPAE38P&#13;
+7Xt/W+nJak0o2e1HnJQPtI5F2MspLvqD2rQXJit7wBJCoTE0S1gzsrOt3xbP9vwq4G20e2x6F80l&#13;
+whJCeZTXCo7blQQ/hlEvyerdhwlq7IEvANpmLA==</SignatureValue><KeyInfo><KeyValue><RSAKeyValue><Modulus>p3WVYaRJG7EABjbAdqDYZXFSTV1nHY9Ol9A5+W8t5xwBXBryZCGWxERGr5AryKWPxd+qzjj+cFpx&#13;
 xkM6N18jEhQIx/CEZePEJqpluBO5w2wTEOe7hqtMatqgDDMeDRxUuIpP8LGP00vh1wyDFFew90d9&#13;
 dvT3bcLvFh3a3ap9bTm6aBqPup5CXpzrwIU2wZfgkDytYVBm+8bHkMaUrgpNyM+5BAg2zl/Fqw0q&#13;
 otjaGr7PzbH+urCvaGbKLMPoWkVLIgAE8Qw98HTfoYSFHC7VYQySrzIinaOBFSgViR72kHemH2lW&#13;
-jDQeHiY0VIoPik/jVVIpjWe6zzeZ2S66Q/LmjQ==</Modulus>
-          <Exponent>AQAB</Exponent>
-        </RSAKeyValue>
-      </KeyValue>
-      <KeyName>2fdeb8e7d030a2209daa01861a964fedecf2bcc1</KeyName>
-    </KeyInfo>
-  </Signature>
-</ns2:SoftwareIdentity>
+jDQeHiY0VIoPik/jVVIpjWe6zzeZ2S66Q/LmjQ==</Modulus><Exponent>AQAB</Exponent></RSAKeyValue></KeyValue><KeyName>2fdeb8e7d030a2209daa01861a964fedecf2bcc1</KeyName></KeyInfo></Signature></ns2:SoftwareIdentity>

--- a/data/pcrim/laptop.default.3.swidtag
+++ b/data/pcrim/laptop.default.3.swidtag
@@ -1,44 +1,9 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<ns2:SoftwareIdentity xmlns:ns2="http://standards.iso.org/iso/19770/-2/2015/schema.xsd" xmlns:ns3="http://www.w3.org/2000/09/xmldsig#" corpus="false" name="TCG RIM example" patch="false" supplemental="false" tagId="ca366cd7-b1a6-4afa-a5b1-2d7ebd8d9c" tagVersion="1" version="0.1" versionScheme="multipartnumeric" xml:lang="en">
-  <ns2:Entity name="HIRS" regid="www.example.com" role="softwareCreator tagCreator"/>
-  <ns2:Link href="https://Example.com/support/ProductA/firmware/installfiles" rel="installationmedia"/>
-  <ns2:Meta xmlns:rim="https://trustedcomputinggroup.org/wp-content/uploads/TCG_RIM_Model" rim:bindingSpec="IOT RIM" rim:bindingSpecVersion="1.2" rim:platformManufacturerId="00201234" rim:platformManufacturerStr="Example.com" rim:platformModel="ProductA"/>
-  <ns2:Payload>
-    <ns2:Directory xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="" xsi:type="ns2:Directory">
-      <ns2:File xmlns:SHA256="http://www.w3.org/2001/04/xmlenc#sha256" SHA256:hash="4479ca722623f8c47b703996ced3cbd981b06b1ae8a897db70137e0b7c546848" name="pcrim/TpmLog.bin" size="0" xsi:type="ns2:File"/>
-      <ns2:File xmlns:SHA256="http://www.w3.org/2001/04/xmlenc#sha256" SHA256:hash="bc120b2d8752bc6eb228b5b433825d766183985cf02d7ab678210901a9730932" name="pcrim/laptop.default.1.rimel" size="0" xsi:type="ns2:File"/>
-      <ns2:File xmlns:SHA256="http://www.w3.org/2001/04/xmlenc#sha256" SHA256:hash="a1704e9cd5727c5429d16bc2829e2890aa358c59b4f3d2e191c3eaa751520ce8" name="pcrim/laptop_varOsInstall_oem.1.rimel" size="0" xsi:type="ns2:File"/>
-    </ns2:Directory>
-  </ns2:Payload>
-  <Signature xmlns="http://www.w3.org/2000/09/xmldsig#">
-    <SignedInfo>
-      <CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/>
-      <SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
-      <Reference URI="">
-        <Transforms>
-          <Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
-        </Transforms>
-        <DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
-        <DigestValue>0J/p2s4Uz/iOPMYYMi3PtzP211b+sSN6fwhbyrFXaiU=</DigestValue>
-      </Reference>
-    </SignedInfo>
-    <SignatureValue>D1j79SHCi+rR8WPqrSW5nXkB0cQcRJEBK6dTJ4bI1QABDnAUtzF3YGV5Jsak0S6YRfyDwHMs0c2g&#13;
-V7RWTMUVzKwPMRMffHWrI/THQfZvkmzISwAOxoPdk/z36Dkf0RYeLHfDl1wOBEVOSHAZSaJ3eUa9&#13;
-crAn/penV0MLJdv5o7WEWAuFuLh83788YPmLIZt+Ujc9fZhA12p0JjlQ2s6uiz3qMspt2wKGIk3g&#13;
-nCiRrio829CADlenDNOp3x8QbE0/OwWSBS3OyfLSFpbrbAy8y9dnt4LrQDs+uyMFpOicc82SzOoh&#13;
-icGeizQbd3+oqExLzkZCQSDJy2K5loZ0TW6pdQ==</SignatureValue>
-    <KeyInfo>
-      <KeyValue>
-        <RSAKeyValue>
-          <Modulus>p3WVYaRJG7EABjbAdqDYZXFSTV1nHY9Ol9A5+W8t5xwBXBryZCGWxERGr5AryKWPxd+qzjj+cFpx&#13;
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><ns2:SoftwareIdentity xmlns:ns2="http://standards.iso.org/iso/19770/-2/2015/schema.xsd" xmlns:ns3="http://www.w3.org/2000/09/xmldsig#" corpus="false" name="TCG RIM example" patch="false" supplemental="false" tagId="ca366cd7-b1a6-4afa-a5b1-2d7ebd8d9c" tagVersion="1" version="0.1" versionScheme="multipartnumeric" xml:lang="en"><ns2:Entity name="HIRS" regid="www.example.com" role="softwareCreator tagCreator"/><ns2:Link href="https://Example.com/support/ProductA/firmware/installfiles" rel="installationmedia"/><ns2:Meta xmlns:rim="https://trustedcomputinggroup.org/wp-content/uploads/TCG_RIM_Model" rim:bindingSpec="IOT RIM" rim:bindingSpecVersion="1.2" rim:platformManufacturerId="00201234" rim:platformManufacturerStr="Example.com" rim:platformModel="ProductA"/><ns2:Payload><ns2:Directory xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" location="" name="" xsi:type="ns2:Directory"><ns2:File xmlns:SHA256="http://www.w3.org/2001/04/xmlenc#sha256" SHA256:hash="4479ca722623f8c47b703996ced3cbd981b06b1ae8a897db70137e0b7c546848" name="TpmLog.bin" size="0" xsi:type="ns2:File"/><ns2:File xmlns:SHA256="http://www.w3.org/2001/04/xmlenc#sha256" SHA256:hash="bc120b2d8752bc6eb228b5b433825d766183985cf02d7ab678210901a9730932" name="laptop.default.1.rimel" size="0" xsi:type="ns2:File"/><ns2:File xmlns:SHA256="http://www.w3.org/2001/04/xmlenc#sha256" SHA256:hash="a1704e9cd5727c5429d16bc2829e2890aa358c59b4f3d2e191c3eaa751520ce8" name="laptop_varOsInstall_oem.1.rimel" size="0" xsi:type="ns2:File"/></ns2:Directory></ns2:Payload><Signature xmlns="http://www.w3.org/2000/09/xmldsig#"><SignedInfo><CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/><SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/><Reference URI=""><Transforms><Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/></Transforms><DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/><DigestValue>cVeAvbtNA6f2DMABwgxv6zqHuIf3e3TqEfUXogi+S8E=</DigestValue></Reference></SignedInfo><SignatureValue>IEVq8c3LyvyDEWnobWvlgxYpnkETA34v4vIRR5AgxPl5rkv6Kyv58taeMwHB9Fy6inGjUmlpHo6o&#13;
+wgMsKP9+T0qRhRXdpsZ/d/WsEBHyexG78OCVUeQ+xAXZXZCXVu+uBmG5j4u65ZjkQmitSUaKhGOp&#13;
+ODmPhoy4Ud4b1ybqZLbxxvDDO8DbpqKGKkzLaA3Ia56MiIFdSb1JVkoTx62SMkiiU2xmHdRC4kl9&#13;
+lBcdWkLSo9qPl5WKX14hb2SnuMkLIL65BHXNbkcHw7P7m0DA/9gAyM75J+riS42QnJt/j7jRJjiZ&#13;
+ipmByL49mEpb8DZMPeISbNOja0Bm1V2DUSPb6g==</SignatureValue><KeyInfo><KeyValue><RSAKeyValue><Modulus>p3WVYaRJG7EABjbAdqDYZXFSTV1nHY9Ol9A5+W8t5xwBXBryZCGWxERGr5AryKWPxd+qzjj+cFpx&#13;
 xkM6N18jEhQIx/CEZePEJqpluBO5w2wTEOe7hqtMatqgDDMeDRxUuIpP8LGP00vh1wyDFFew90d9&#13;
 dvT3bcLvFh3a3ap9bTm6aBqPup5CXpzrwIU2wZfgkDytYVBm+8bHkMaUrgpNyM+5BAg2zl/Fqw0q&#13;
 otjaGr7PzbH+urCvaGbKLMPoWkVLIgAE8Qw98HTfoYSFHC7VYQySrzIinaOBFSgViR72kHemH2lW&#13;
-jDQeHiY0VIoPik/jVVIpjWe6zzeZ2S66Q/LmjQ==</Modulus>
-          <Exponent>AQAB</Exponent>
-        </RSAKeyValue>
-      </KeyValue>
-      <KeyName>2fdeb8e7d030a2209daa01861a964fedecf2bcc1</KeyName>
-    </KeyInfo>
-  </Signature>
-</ns2:SoftwareIdentity>
+jDQeHiY0VIoPik/jVVIpjWe6zzeZ2S66Q/LmjQ==</Modulus><Exponent>AQAB</Exponent></RSAKeyValue></KeyValue><KeyName>2fdeb8e7d030a2209daa01861a964fedecf2bcc1</KeyName></KeyInfo></Signature></ns2:SoftwareIdentity>

--- a/data/pcrim/laptop.default.bad-sig.swidtag
+++ b/data/pcrim/laptop.default.bad-sig.swidtag
@@ -1,42 +1,10 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<ns2:SoftwareIdentity xmlns:ns2="http://standards.iso.org/iso/19770/-2/2015/schema.xsd" xmlns:ns3="http://www.w3.org/2000/09/xmldsig#" corpus="false" name="TCG RIM example" patch="false" supplemental="false" tagId="ca366cd7-b1a6-4afa-a5b1-2d7ebd8d9c" tagVersion="1" version="0.1" versionScheme="multipartnumeric" xml:lang="en">
-  <ns2:Entity name="HIRS" regid="www.example.com" role="softwareCreator tagCreator"/>
-  <ns2:Link href="https://Example.com/support/ProductA/firmware/installfiles" rel="installationmedia"/>
-  <ns2:Meta xmlns:rim="https://trustedcomputinggroup.org/wp-content/uploads/TCG_RIM_Model" rim:bindingSpec="IOT RIM" rim:bindingSpecVersion="1.2" rim:platformManufacturerId="00201234" rim:platformManufacturerStr="Example.com" rim:platformModel="Bad_Product"/>
-  <ns2:Payload>
-    <ns2:Directory xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Test" xsi:type="ns2:Directory">
-      <ns2:File xmlns:SHA256="http://www.w3.org/2001/04/xmlenc#sha256" SHA256:hash="4479ca722623f8c47b703996ced3cbd981b06b1ae8a897db70137e0b7c546848" name="TpmLog.bin" size="7459" xsi:type="ns2:File"/>
-    </ns2:Directory>
-  </ns2:Payload>
-  <Signature xmlns="http://www.w3.org/2000/09/xmldsig#">
-    <SignedInfo>
-      <CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/>
-      <SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
-      <Reference URI="">
-        <Transforms>
-          <Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
-        </Transforms>
-        <DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
-        <DigestValue>TqJg3fUAc3G+dbKTM6WYGdOyeLv5mURXRG7dUdqScKI=</DigestValue>
-      </Reference>
-    </SignedInfo>
-    <SignatureValue>j6eeaoUkho33St4Ukc9gLUTKjroL1QcWLJoLnH+EbZ2mcXH/j+edh7HhvZYPwS1hGwt3HWPcToM5&#13;
-gVWODTaA7Ud3nyHdPkuOp3MMgushOg0cmb9KmV4JEXMrTAK9CSLf60zbpdVVwbIn57QGDP4aFXmr&#13;
-UDDebquKss6x0IAPAWw79/RAdRuEyu1gkt0nPg/mSH7DehH/pJAVTBVVJuFfjcg7gOx3j92LkOdE&#13;
-+z01StGBGtrirlpKPg+yu9cE5SGoYUyCts0Fi0gbLBOgJ9gr9lNO2KZZnwa9nyDmzP3Z5SkUd+ig&#13;
-qARtNfsDEXNCrnTLzTHnp+MyV/BHVQm/CFgEoQ==</SignatureValue>
-    <KeyInfo>
-      <KeyValue>
-        <RSAKeyValue>
-          <Modulus>p3WVYaRJG7EABjbAdqDYZXFSTV1nHY9Ol9A5+W8t5xwBXBryZCGWxERGr5AryKWPxd+qzjj+cFpx&#13;
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><ns2:SoftwareIdentity xmlns:ns2="http://standards.iso.org/iso/19770/-2/2015/schema.xsd" xmlns:ns3="http://www.w3.org/2000/09/xmldsig#" corpus="false" name="TCG RIM example" patch="false" supplemental="false" tagId="ca366cd7-b1a6-4afa-a5b1-2d7ebd8d9c" tagVersion="1" version="0.1" versionScheme="multipartnumeric" xml:lang="en"><ns2:Entity name="HIRS" regid="www.example.com" role="softwareCreator tagCreator"/><ns2:Link href="https://Example.com/support/ProductA/firmware/installfiles" rel="installationmedia"/><ns2:Meta xmlns:rim="https://trustedcomputinggroup.org/wp-content/uploads/TCG_RIM_Model" rim:bindingSpec="IOT RIM" rim:bindingSpecVersion="1.2" rim:platformManufacturerId="00201234" rim:platformManufacturerStr="Example.com" rim:platformModel="ProductA"/><ns2:Payload><ns2:Directory xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" location="data/pcrim/" name="" xsi:type="ns2:Directory"><ns2:File xmlns:SHA256="http://www.w3.org/2001/04/xmlenc#sha256" SHA256:hash="4479ca722623f8c47b703996ced3cbd981b06b1ae8a897db70137e0b7c546848" name="TpmLog.bin" size="7459" xsi:type="ns2:File"/></ns2:Directory></ns2:Payload>
+	<Signature xmlns="http://www.w3.org/2000/09/xmldsig#"><SignedInfo><CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/><SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/><Reference URI=""><Transforms><Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/></Transforms><DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/><DigestValue>6V6eJHMAbs0ywSEmfJ/n8yY1GCvAsZy8waeCrel9xE4=</DigestValue></Reference></SignedInfo><SignatureValue>DdBvwex+fRGW+omZNYrcHIHl2avnLs+YwbujA9bltjXQ5Atuhr2cMieT/U9rSaQwRa7NswoHJ0Jy&#13;
+P6x+CC/a1lrytsLHSwjubRVw/bXQUHGQfF2sfJ4C2NF/kbl9+aJWblZoQirLm9teScpkFt4D54cY&#13;
+nxxH5p5dtpikmZLF9wLeQDgggLD5sWVBophIVeoQRLHeTOHzY/lJX+A2uCYmBtW6m5rX0dPAE38P&#13;
+7Xt/W+nJak0o2e1HnJQPtI5F2MspLvqD2rQXJit7wBJCoTE0S1gzsrOt3xbP9vwq4G20e2x6F80l&#13;
+whJCeZTXCo7blQQ/hlEvyerdhwlq7IEvANpmLA==</SignatureValue><KeyInfo><KeyValue><RSAKeyValue><Modulus>p3WVYaRJG7EABjbAdqDYZXFSTV1nHY9Ol9A5+W8t5xwBXBryZCGWxERGr5AryKWPxd+qzjj+cFpx&#13;
 xkM6N18jEhQIx/CEZePEJqpluBO5w2wTEOe7hqtMatqgDDMeDRxUuIpP8LGP00vh1wyDFFew90d9&#13;
 dvT3bcLvFh3a3ap9bTm6aBqPup5CXpzrwIU2wZfgkDytYVBm+8bHkMaUrgpNyM+5BAg2zl/Fqw0q&#13;
 otjaGr7PzbH+urCvaGbKLMPoWkVLIgAE8Qw98HTfoYSFHC7VYQySrzIinaOBFSgViR72kHemH2lW&#13;
-jDQeHiY0VIoPik/jVVIpjWe6zzeZ2S66Q/LmjQ==</Modulus>
-          <Exponent>AQAB</Exponent>
-        </RSAKeyValue>
-      </KeyValue>
-      <KeyName>2fdeb8e7d030a2209daa01861a964fedecf2bcc1</KeyName>
-    </KeyInfo>
-  </Signature>
-</ns2:SoftwareIdentity>
+jDQeHiY0VIoPik/jVVIpjWe6zzeZ2S66Q/LmjQ==</Modulus><Exponent>AQAB</Exponent></RSAKeyValue></KeyValue><KeyName>2fdeb8e7d030a2209daa01861a964fedecf2bcc1</KeyName></KeyInfo></Signature></ns2:SoftwareIdentity>

--- a/data/pcrim/laptop.default.bad-support-name.swidtag
+++ b/data/pcrim/laptop.default.bad-support-name.swidtag
@@ -1,42 +1,9 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<ns2:SoftwareIdentity xmlns:ns2="http://standards.iso.org/iso/19770/-2/2015/schema.xsd" xmlns:ns3="http://www.w3.org/2000/09/xmldsig#" corpus="false" name="TCG RIM example" patch="false" supplemental="false" tagId="ca366cd7-b1a6-4afa-a5b1-2d7ebd8d9c" tagVersion="1" version="0.1" versionScheme="multipartnumeric" xml:lang="en">
-  <ns2:Entity name="HIRS" regid="www.example.com" role="softwareCreator tagCreator"/>
-  <ns2:Link href="https://Example.com/support/ProductA/firmware/installfiles" rel="installationmedia"/>
-  <ns2:Meta xmlns:rim="https://trustedcomputinggroup.org/wp-content/uploads/TCG_RIM_Model" rim:bindingSpec="IOT RIM" rim:bindingSpecVersion="1.2" rim:platformManufacturerId="00201234" rim:platformManufacturerStr="Example.com" rim:platformModel="ProductA"/>
-  <ns2:Payload>
-    <ns2:Directory xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Test" xsi:type="ns2:Directory">
-      <ns2:File xmlns:SHA256="http://www.w3.org/2001/04/xmlenc#sha256" SHA256:hash="4479ca722623f8c47b703996ced3cbd981b06b1ae8a897db70137e0b7c546848" name="pcrim/TpmLog.bin" size="7459" xsi:type="ns2:File"/>
-    </ns2:Directory>
-  </ns2:Payload>
-  <Signature xmlns="http://www.w3.org/2000/09/xmldsig#">
-    <SignedInfo>
-      <CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/>
-      <SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
-      <Reference URI="">
-        <Transforms>
-          <Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
-        </Transforms>
-        <DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
-        <DigestValue>cL7IclUTIBhOQXwWj+EByACi1/eJDaHgfWCtDPm3fyA=</DigestValue>
-      </Reference>
-    </SignedInfo>
-    <SignatureValue>JmYFqIugMlsLFT7peKBKdlZeGkac2d5sU74IIZ4oNwDrgRYlUIS4vQ2MFzIYpQKx3BLN6KN88kjF&#13;
-uKlZOdH6zg7LhClobnqDWIGjg6CQPDLv4HGDVXDexDaTdYiBKJrSZr0kDFDCGH6to/mQPYKDiwi3&#13;
-UsUP+EM/QFIQVWV+6Rs+1Z1us+fMLbd1KTVjjz7talUaaopzkbYHJpA/7x7tv7lC6bq2BbUYbIKC&#13;
-RdHFSKJePUi8QF0PRzkDCYa6obpLdgtivtVtTW2I6sbacBme1aypheHek9HQTIHD9aGPnbiLl2Pg&#13;
-t0GZPQuRor8KDnNJfgUjLHxS+4uZSJh2T8Ti5Q==</SignatureValue>
-    <KeyInfo>
-      <KeyValue>
-        <RSAKeyValue>
-          <Modulus>p3WVYaRJG7EABjbAdqDYZXFSTV1nHY9Ol9A5+W8t5xwBXBryZCGWxERGr5AryKWPxd+qzjj+cFpx&#13;
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><ns2:SoftwareIdentity xmlns:ns2="http://standards.iso.org/iso/19770/-2/2015/schema.xsd" xmlns:ns3="http://www.w3.org/2000/09/xmldsig#" corpus="false" name="TCG RIM example" patch="false" supplemental="false" tagId="ca366cd7-b1a6-4afa-a5b1-2d7ebd8d9c" tagVersion="1" version="0.1" versionScheme="multipartnumeric" xml:lang="en"><ns2:Entity name="HIRS" regid="www.example.com" role="softwareCreator tagCreator"/><ns2:Link href="https://Example.com/support/ProductA/firmware/installfiles" rel="installationmedia"/><ns2:Meta xmlns:rim="https://trustedcomputinggroup.org/wp-content/uploads/TCG_RIM_Model" rim:bindingSpec="IOT RIM" rim:bindingSpecVersion="1.2" rim:platformManufacturerId="00201234" rim:platformManufacturerStr="Example.com" rim:platformModel="ProductA"/><ns2:Payload><ns2:Directory xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" location="data/pcrim/" name="" xsi:type="ns2:Directory"><ns2:File xmlns:SHA256="http://www.w3.org/2001/04/xmlenc#sha256" SHA256:hash="4479ca722623f8c47b703996ced3cbd981b06b1ae8a897db70137e0b7c546848" name="pcrim/TpmLog.bin" size="7459" xsi:type="ns2:File"/></ns2:Directory></ns2:Payload><Signature xmlns="http://www.w3.org/2000/09/xmldsig#"><SignedInfo><CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/><SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/><Reference URI=""><Transforms><Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/></Transforms><DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/><DigestValue>6V6eJHMAbs0ywSEmfJ/n8yY1GCvAsZy8waeCrel9xE4=</DigestValue></Reference></SignedInfo><SignatureValue>DdBvwex+fRGW+omZNYrcHIHl2avnLs+YwbujA9bltjXQ5Atuhr2cMieT/U9rSaQwRa7NswoHJ0Jy&#13;
+P6x+CC/a1lrytsLHSwjubRVw/bXQUHGQfF2sfJ4C2NF/kbl9+aJWblZoQirLm9teScpkFt4D54cY&#13;
+nxxH5p5dtpikmZLF9wLeQDgggLD5sWVBophIVeoQRLHeTOHzY/lJX+A2uCYmBtW6m5rX0dPAE38P&#13;
+7Xt/W+nJak0o2e1HnJQPtI5F2MspLvqD2rQXJit7wBJCoTE0S1gzsrOt3xbP9vwq4G20e2x6F80l&#13;
+whJCeZTXCo7blQQ/hlEvyerdhwlq7IEvANpmLA==</SignatureValue><KeyInfo><KeyValue><RSAKeyValue><Modulus>p3WVYaRJG7EABjbAdqDYZXFSTV1nHY9Ol9A5+W8t5xwBXBryZCGWxERGr5AryKWPxd+qzjj+cFpx&#13;
 xkM6N18jEhQIx/CEZePEJqpluBO5w2wTEOe7hqtMatqgDDMeDRxUuIpP8LGP00vh1wyDFFew90d9&#13;
 dvT3bcLvFh3a3ap9bTm6aBqPup5CXpzrwIU2wZfgkDytYVBm+8bHkMaUrgpNyM+5BAg2zl/Fqw0q&#13;
 otjaGr7PzbH+urCvaGbKLMPoWkVLIgAE8Qw98HTfoYSFHC7VYQySrzIinaOBFSgViR72kHemH2lW&#13;
-jDQeHiY0VIoPik/jVVIpjWe6zzeZ2S66Q/LmjQ==</Modulus>
-          <Exponent>AQAB</Exponent>
-        </RSAKeyValue>
-      </KeyValue>
-      <KeyName>2fdeb8e7d030a2209daa01861a964fedecf2bcc1</KeyName>
-    </KeyInfo>
-  </Signature>
-</ns2:SoftwareIdentity>
+jDQeHiY0VIoPik/jVVIpjWe6zzeZ2S66Q/LmjQ==</Modulus><Exponent>AQAB</Exponent></RSAKeyValue></KeyValue><KeyName>2fdeb8e7d030a2209daa01861a964fedecf2bcc1</KeyName></KeyInfo></Signature></ns2:SoftwareIdentity>

--- a/data/pcrim/laptop.patch.1.swidtag
+++ b/data/pcrim/laptop.patch.1.swidtag
@@ -1,42 +1,9 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<ns2:SoftwareIdentity xmlns:ns2="http://standards.iso.org/iso/19770/-2/2015/schema.xsd" xmlns:ns3="http://www.w3.org/2000/09/xmldsig#" corpus="false" name="TCG RIM example" patch="true" supplemental="false" tagId="ca366cd7-b1a6-4afa-a5b1-2d7ebd8d9c" tagVersion="2" version="0.2" xml:lang="en">
-  <ns2:Entity name="HIRS" regid="www.example.com" role="softwareCreator tagCreator"/>
-  <ns2:Link href="https://Example.com/support/ProductA/firmware/installfiles" rel="installationmedia"/>
-  <ns2:Meta xmlns:rim="https://trustedcomputinggroup.org/wp-content/uploads/TCG_RIM_Model" rim:bindingSpec="IOT RIM" rim:bindingSpecVersion="1.2" rim:platformManufacturerId="00201234" rim:platformManufacturerStr="Example.com" rim:platformModel="ProductA" rim:rimLinkHash="0b4308b37a110537ac8c48c443e34bcd303c75a3860e6b0daf8a7cbcd51cc0da"/>
-  <ns2:Payload>
-    <ns2:Directory xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Test" xsi:type="ns2:Directory">
-      <ns2:File xmlns:SHA256="http://www.w3.org/2001/04/xmlenc#sha256" SHA256:hash="4479ca722623f8c47b703996ced3cbd981b06b1ae8a897db70137e0b7c546848" name="pcrim/TpmLog.bin" size="7459" xsi:type="ns2:File"/>
-    </ns2:Directory>
-  </ns2:Payload>
-  <Signature xmlns="http://www.w3.org/2000/09/xmldsig#">
-    <SignedInfo>
-      <CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/>
-      <SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
-      <Reference URI="">
-        <Transforms>
-          <Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
-        </Transforms>
-        <DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
-        <DigestValue>G45esRy6aRiXCn8l1PAhhKKHoQbjEirask+Kl2fOv0M=</DigestValue>
-      </Reference>
-    </SignedInfo>
-    <SignatureValue>IBptb0dyt0KRYzXuLwbFfevvRtlZesHmQhvZj+J6NlYZqC9TUJuqnrT8yBbWAW0U+hzWo+rsDrlG&#13;
-tslb1xf04/YJurCqh24eUk4fr//pSfpZsdDj84mL8j0UYMxlIyqYb3zFAY2zaMDxFTtRt/a5K4P+&#13;
-Jk6rluDvk6rCgOoRxPHTw2uhHsKErCKxfRpRa2Soh1KI9Fl7sHr9nlzj+/c5U4YWfLjK21N+FsT+&#13;
-8aAYlWX7aZKAbMcjeJFSHbYHQ403CrEQLUYvOFvusBkumGstIHQWYawUCHipB/Nl3E3h9Yd78QyS&#13;
-xLTHyVKCRparIZeP0OuM9DIuRQQB5YGpr3as+g==</SignatureValue>
-    <KeyInfo>
-      <KeyValue>
-        <RSAKeyValue>
-          <Modulus>p3WVYaRJG7EABjbAdqDYZXFSTV1nHY9Ol9A5+W8t5xwBXBryZCGWxERGr5AryKWPxd+qzjj+cFpx&#13;
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><ns2:SoftwareIdentity xmlns:ns2="http://standards.iso.org/iso/19770/-2/2015/schema.xsd" xmlns:ns3="http://www.w3.org/2000/09/xmldsig#" corpus="false" name="TCG RIM example" patch="true" supplemental="false" tagId="ca366cd7-b1a6-4afa-a5b1-2d7ebd8d9c" tagVersion="2" version="0.2" xml:lang="en"><ns2:Entity name="HIRS" regid="www.example.com" role="softwareCreator tagCreator"/><ns2:Link href="https://Example.com/support/ProductA/firmware/installfiles" rel="installationmedia"/><ns2:Meta xmlns:rim="https://trustedcomputinggroup.org/wp-content/uploads/TCG_RIM_Model" rim:bindingSpec="IOT RIM" rim:bindingSpecVersion="1.2" rim:platformManufacturerId="00201234" rim:platformManufacturerStr="Example.com" rim:platformModel="ProductA" rim:rimLinkHash="0b4308b37a110537ac8c48c443e34bcd303c75a3860e6b0daf8a7cbcd51cc0da"/><ns2:Payload><ns2:Directory xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" location="" name="Test" xsi:type="ns2:Directory"><ns2:File xmlns:SHA256="http://www.w3.org/2001/04/xmlenc#sha256" SHA256:hash="4479ca722623f8c47b703996ced3cbd981b06b1ae8a897db70137e0b7c546848" name="TpmLog.bin" size="7459" xsi:type="ns2:File"/></ns2:Directory></ns2:Payload><Signature xmlns="http://www.w3.org/2000/09/xmldsig#"><SignedInfo><CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/><SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/><Reference URI=""><Transforms><Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/></Transforms><DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/><DigestValue>nim+aYGMZn/jWxfYylV+rPRztbU+bb9ykSiZQvAaEUg=</DigestValue></Reference></SignedInfo><SignatureValue>FwO7B5XihJ2L98Pes0I1Gd3e4K5KLyDSRPikannTIbVZ1R2loMYrGu0zAHh0rslMmgKMu/Vgat2K&#13;
+9qPzoFS4ffDaHXDaB6Gqs+RCxGiv4k7VlQPJGjUOo8vPwyzAEGJ/SqKdqA4Fl7ElNkaGHSDlKdSh&#13;
+IleDRa1NKQTC0e1hnTDqnh7Bm3D4Y7fX+58Yg5jdHvSd8IeVPcatYUac1g/1hROWI+3NQGxxsCmx&#13;
+EaE3FebCqEmetW19FMYA5ZGZOSBQR7JVbdiAy5ydlb5QwGHRsLgB+cikIMAy0jQSMBMbLBE3xI7M&#13;
+iOw5bQXoT5bR7I2yjL4ydDJ8WWLju/HD9Nq0WA==</SignatureValue><KeyInfo><KeyValue><RSAKeyValue><Modulus>p3WVYaRJG7EABjbAdqDYZXFSTV1nHY9Ol9A5+W8t5xwBXBryZCGWxERGr5AryKWPxd+qzjj+cFpx&#13;
 xkM6N18jEhQIx/CEZePEJqpluBO5w2wTEOe7hqtMatqgDDMeDRxUuIpP8LGP00vh1wyDFFew90d9&#13;
 dvT3bcLvFh3a3ap9bTm6aBqPup5CXpzrwIU2wZfgkDytYVBm+8bHkMaUrgpNyM+5BAg2zl/Fqw0q&#13;
 otjaGr7PzbH+urCvaGbKLMPoWkVLIgAE8Qw98HTfoYSFHC7VYQySrzIinaOBFSgViR72kHemH2lW&#13;
-jDQeHiY0VIoPik/jVVIpjWe6zzeZ2S66Q/LmjQ==</Modulus>
-          <Exponent>AQAB</Exponent>
-        </RSAKeyValue>
-      </KeyValue>
-      <KeyName>2fdeb8e7d030a2209daa01861a964fedecf2bcc1</KeyName>
-    </KeyInfo>
-  </Signature>
-</ns2:SoftwareIdentity>
+jDQeHiY0VIoPik/jVVIpjWe6zzeZ2S66Q/LmjQ==</Modulus><Exponent>AQAB</Exponent></RSAKeyValue></KeyValue><KeyName>2fdeb8e7d030a2209daa01861a964fedecf2bcc1</KeyName></KeyInfo></Signature></ns2:SoftwareIdentity>

--- a/data/pcrim/laptop.supplemental.1.swidtag
+++ b/data/pcrim/laptop.supplemental.1.swidtag
@@ -1,42 +1,9 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<ns2:SoftwareIdentity xmlns:ns2="http://standards.iso.org/iso/19770/-2/2015/schema.xsd" xmlns:ns3="http://www.w3.org/2000/09/xmldsig#" corpus="false" name="TCG RIM example" patch="false" supplemental="true" tagId="ca366cd7-b1a6-4afa-a5b1-2d7ebd8d9c" tagVersion="2" version="0.2" xml:lang="en">
-  <ns2:Entity name="HIRS" regid="www.example.com" role="softwareCreator tagCreator"/>
-  <ns2:Link href="https://Example.com/support/ProductA/firmware/installfiles" rel="installationmedia"/>
-  <ns2:Meta xmlns:rim="https://trustedcomputinggroup.org/wp-content/uploads/TCG_RIM_Model" rim:bindingSpec="IOT RIM" rim:bindingSpecVersion="1.2" rim:platformManufacturerId="00201234" rim:platformManufacturerStr="Example.com" rim:platformModel="ProductA" rim:rimLinkHash="0b4308b37a110537ac8c48c443e34bcd303c75a3860e6b0daf8a7cbcd51cc0da"/>
-  <ns2:Payload>
-    <ns2:Directory xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Test" xsi:type="ns2:Directory">
-      <ns2:File xmlns:SHA256="http://www.w3.org/2001/04/xmlenc#sha256" SHA256:hash="4479ca722623f8c47b703996ced3cbd981b06b1ae8a897db70137e0b7c546848" name="pcrim/TpmLog.bin" size="7459" xsi:type="ns2:File"/>
-    </ns2:Directory>
-  </ns2:Payload>
-  <Signature xmlns="http://www.w3.org/2000/09/xmldsig#">
-    <SignedInfo>
-      <CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/>
-      <SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
-      <Reference URI="">
-        <Transforms>
-          <Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
-        </Transforms>
-        <DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
-        <DigestValue>i/q1zy5gNPODdR/JA1VlRXm5U0RjIM4wc6hJ9WM7Sn8=</DigestValue>
-      </Reference>
-    </SignedInfo>
-    <SignatureValue>ldAuu1nX/zg3r6zUO7AcTfX0s9F2D4ICn51VrR18MZHWXuqKJkuT/V8YA9pGRqd1955tD6UAMm5B&#13;
-oZxchEglrxKSSbS6b87utaAKogaixwYU7988+VTqAfi4nlCIX9oMQ9LSscmEVUr7zGq6HU4eIAmV&#13;
-9A1/Wig0tp48RhiyAOYLALW3fll/gzzbehcHn9TKd3y1/xfklvu6Ujv1UNpvuCsCFHYl2w6dohH3&#13;
-udMXJfgwhod+sYwXxQNpno0uW0KyguAuTRyzvM/RcSk5DLQZMGFsKnMnxkLfkCVpUxXsZhPqYXGz&#13;
-73ye67HdR7ugjHmz3On+/ouoirKnvg2AQEqJeQ==</SignatureValue>
-    <KeyInfo>
-      <KeyValue>
-        <RSAKeyValue>
-          <Modulus>p3WVYaRJG7EABjbAdqDYZXFSTV1nHY9Ol9A5+W8t5xwBXBryZCGWxERGr5AryKWPxd+qzjj+cFpx&#13;
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><ns2:SoftwareIdentity xmlns:ns2="http://standards.iso.org/iso/19770/-2/2015/schema.xsd" xmlns:ns3="http://www.w3.org/2000/09/xmldsig#" corpus="false" name="TCG RIM example" patch="false" supplemental="true" tagId="ca366cd7-b1a6-4afa-a5b1-2d7ebd8d9c" tagVersion="2" version="0.2" xml:lang="en"><ns2:Entity name="HIRS" regid="www.example.com" role="softwareCreator tagCreator"/><ns2:Link href="https://Example.com/support/ProductA/firmware/installfiles" rel="installationmedia"/><ns2:Meta xmlns:rim="https://trustedcomputinggroup.org/wp-content/uploads/TCG_RIM_Model" rim:bindingSpec="IOT RIM" rim:bindingSpecVersion="1.2" rim:platformManufacturerId="00201234" rim:platformManufacturerStr="Example.com" rim:platformModel="ProductA" rim:rimLinkHash="0b4308b37a110537ac8c48c443e34bcd303c75a3860e6b0daf8a7cbcd51cc0da"/><ns2:Payload><ns2:Directory xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" location="" name="Test" xsi:type="ns2:Directory"><ns2:File xmlns:SHA256="http://www.w3.org/2001/04/xmlenc#sha256" SHA256:hash="4479ca722623f8c47b703996ced3cbd981b06b1ae8a897db70137e0b7c546848" name="TpmLog.bin" size="7459" xsi:type="ns2:File"/></ns2:Directory></ns2:Payload><Signature xmlns="http://www.w3.org/2000/09/xmldsig#"><SignedInfo><CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/><SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/><Reference URI=""><Transforms><Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/></Transforms><DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/><DigestValue>wy4pv/rl/3Mj1lOtKm7fkkyFlfpCNglQSs2k7EFLgXg=</DigestValue></Reference></SignedInfo><SignatureValue>jqlenmwuGU8mZZLXeO2CX7ZRTFxq2v48iPgDmvrfiegtSlbsiGXjn21xaJRy3gtUqL5f2YTIaAEU&#13;
+NBn9pYO/qohaqXg7gR9Jtjk2Tz4ieKTbj7UVY6nqArOlcQiTCk7MrWCVLEWyFsq/DfncmI6Xxry8&#13;
+H23bd9c9WvBP3zWvEUvmOSiH/gvmtGmkB4POTNNOq0HXpimuvRx5mymLTSuGep8sWBO5Q6TTuYAc&#13;
+ObCIbz+3SEyF7hSICdPDzLCegRj8gegsZkSxlo7DJ7j4QB3z67esdzoFCcu+rm1RiUs0iHZUbgMC&#13;
+TDAM0EJ4LhTeKKqigF8xsKfffVe9iZlbOmz+Dg==</SignatureValue><KeyInfo><KeyValue><RSAKeyValue><Modulus>p3WVYaRJG7EABjbAdqDYZXFSTV1nHY9Ol9A5+W8t5xwBXBryZCGWxERGr5AryKWPxd+qzjj+cFpx&#13;
 xkM6N18jEhQIx/CEZePEJqpluBO5w2wTEOe7hqtMatqgDDMeDRxUuIpP8LGP00vh1wyDFFew90d9&#13;
 dvT3bcLvFh3a3ap9bTm6aBqPup5CXpzrwIU2wZfgkDytYVBm+8bHkMaUrgpNyM+5BAg2zl/Fqw0q&#13;
 otjaGr7PzbH+urCvaGbKLMPoWkVLIgAE8Qw98HTfoYSFHC7VYQySrzIinaOBFSgViR72kHemH2lW&#13;
-jDQeHiY0VIoPik/jVVIpjWe6zzeZ2S66Q/LmjQ==</Modulus>
-          <Exponent>AQAB</Exponent>
-        </RSAKeyValue>
-      </KeyValue>
-      <KeyName>2fdeb8e7d030a2209daa01861a964fedecf2bcc1</KeyName>
-    </KeyInfo>
-  </Signature>
-</ns2:SoftwareIdentity>
+jDQeHiY0VIoPik/jVVIpjWe6zzeZ2S66Q/LmjQ==</Modulus><Exponent>AQAB</Exponent></RSAKeyValue></KeyValue><KeyName>2fdeb8e7d030a2209daa01861a964fedecf2bcc1</KeyName></KeyInfo></Signature></ns2:SoftwareIdentity>

--- a/src/main/java/rimtool/Main.java
+++ b/src/main/java/rimtool/Main.java
@@ -135,7 +135,7 @@ final class Main {
             case CommandDefinitions.CMD_VERIFY:
                 verify(verifyCom.getRimType(), verifyCom.getInFile(), verifyCom.getRimEventLog(),
                         verifyCom.getPublicKey(), verifyCom.getPublicCertificate(), verifyCom.getTruststore(),
-                        verifyCom.getDetachedSignature(), verifyCom.isEmbedded(), verifyCom.isExtract());
+                        verifyCom.getDetachedSignature(), verifyCom.isEmbedded());
                 break;
             case CommandDefinitions.CMD_PRINT:
                 print(printCom.getRimType(), printCom.getInFile());
@@ -487,7 +487,7 @@ final class Main {
      */
     private static void verify(final String rimType, final String inFile, final String supportRim,
                                final String publicKeyFile, final String certPath, final String trustPath,
-                               final String detachedFile, final boolean embedded, final boolean extract) {
+                               final String detachedFile, final boolean embedded) {
         // Get Cert used for cert verification (need cert ID for signature encoding)
         X509Certificate cert = null;
         boolean verified = false;
@@ -512,9 +512,6 @@ final class Main {
         try {
             if (sigType.compareTo("xmlDsig") == 0) {
                 PcClientRim pcRim = new PcClientRim();
-                if (extract) {
-                    pcRim.extractToBeSigned(inFile);
-                }
                 verified = pcRim.validate(inFile, certPath, supportRim, trustPath);
             } else if (sigType.compareTo("cose") == 0) {
                 // Set up the crypto device used for signing

--- a/src/main/java/rimtool/Main.java
+++ b/src/main/java/rimtool/Main.java
@@ -132,7 +132,7 @@ final class Main {
             case CommandDefinitions.CMD_VERIFY:
                 verify(verifyCom.getRimType(), verifyCom.getInFile(), verifyCom.getRimEventLog(),
                         verifyCom.getPublicKey(), verifyCom.getPublicCertificate(), verifyCom.getTruststore(),
-                        verifyCom.getDetachedSignature(), verifyCom.isEmbedded());
+                        verifyCom.getDetachedSignature(), verifyCom.isEmbedded(), verifyCom.isExtract());
                 break;
             case CommandDefinitions.CMD_PRINT:
                 print(printCom.getRimType(), printCom.getInFile());
@@ -480,7 +480,7 @@ final class Main {
      */
     private static void verify(final String rimType, final String inFile, final String supportRim,
                                final String publicKeyFile, final String certPath, final String trustPath,
-                               final String detachedFile, final boolean embedded) {
+                               final String detachedFile, final boolean embedded, final boolean extract) {
         // Get Cert used for cert verification (need cert ID for signature encoding)
         X509Certificate cert = null;
         boolean verified = false;
@@ -505,6 +505,9 @@ final class Main {
         try {
             if (sigType.compareTo("xmlDsig") == 0) {
                 PcClientRim pcRim = new PcClientRim();
+                if (extract) {
+                    pcRim.extractToBeSigned(inFile);
+                }
                 verified = pcRim.validate(inFile, certPath, supportRim, trustPath);
             } else if (sigType.compareTo("cose") == 0) {
                 // Set up the crypto device used for signing

--- a/src/main/java/rimtool/Main.java
+++ b/src/main/java/rimtool/Main.java
@@ -17,6 +17,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import hirs.utils.signature.cose.CoseAlgorithm;
+import hirs.utils.rim.ReferenceManifestValidator;
 import hirs.utils.rim.unsignedRim.GenericRim;
 import hirs.utils.rim.unsignedRim.cbor.ietfCorim.CoRimBuilder;
 import hirs.utils.rim.unsignedRim.xml.pcclientrim.PcClientRim;
@@ -40,6 +41,8 @@ import rimtool.commands.CommandPrint;
 import rimtool.commands.CommandSign;
 import rimtool.commands.CommandVerify;
 import hirs.utils.HexUtils;
+import hirs.utils.swid.SwidTagGateway;
+
 
 /**
  * Command-line application for processing TCG Event Logs.
@@ -228,7 +231,11 @@ final class Main {
                     print += new CoseParser(data).toString("pretty"); break;
                 //RIM types
                 case GenericRim.RIMTYPE_PCRIM:
-                    print = new String(data, StandardCharsets.UTF_8); break;
+                    print = "";
+                    ReferenceManifestValidator validator = new ReferenceManifestValidator();
+                    validator.setRim(data);
+                    SwidTagGateway.writeSwidTagFile(validator.getRim(), "", true);
+                    break;
                 case GenericRim.RIMTYPE_COSWID:
                     print += new CoswidParser(data).toString("pretty"); break;
                 case GenericRim.RIMTYPE_COMP_SWID:

--- a/src/main/java/rimtool/commands/CommandDefinitions.java
+++ b/src/main/java/rimtool/commands/CommandDefinitions.java
@@ -21,6 +21,8 @@ public class CommandDefinitions {
     public static final String ARG_DETACHED_SHORT = "-d";
     public static final String ARG_EMBEDCERT = "--embed-cert";
     public static final String ARG_EMBEDCERT_SHORT = "-e";
+    public static final String ARG_EXTRACT_TO_BE_SIGNED = "--extract";
+    public static final String ARG_EXTRACT_TO_BE_SIGNED_SHORT = "-x";
     public static final String ARG_HELP = "--help";
     public static final String ARG_HELP_SHORT = "-h";
     public static final String ARG_IGNOREVALIDATORS = "--ignore-validators";
@@ -57,6 +59,8 @@ public class CommandDefinitions {
     public static final String PARAM_DESCR_EMBEDCERT =
             "For DSIG: the provided certificate is embedded into the signed swidtag; for COSE: the "
                     + "provided certificate and the thumbprint are embedded into protected header.";
+    public static final String PARA_DESCR_EXTRACT = "For PCRIM, print the base RIM contents to a "
+            + "separate file without the XML signature block.";
     public static final String PARAM_DESCR_HELP = "Print this help text.";
     public static final String PARAM_DESCR_IGNOREVALIDATORS =
             "Ignores the validator checks for testing purposes.";

--- a/src/main/java/rimtool/commands/CommandDefinitions.java
+++ b/src/main/java/rimtool/commands/CommandDefinitions.java
@@ -21,8 +21,6 @@ public class CommandDefinitions {
     public static final String ARG_DETACHED_SHORT = "-d";
     public static final String ARG_EMBEDCERT = "--embed-cert";
     public static final String ARG_EMBEDCERT_SHORT = "-e";
-    public static final String ARG_EXTRACT_TO_BE_SIGNED = "--extract";
-    public static final String ARG_EXTRACT_TO_BE_SIGNED_SHORT = "-x";
     public static final String ARG_HELP = "--help";
     public static final String ARG_HELP_SHORT = "-h";
     public static final String ARG_IGNOREVALIDATORS = "--ignore-validators";
@@ -59,8 +57,6 @@ public class CommandDefinitions {
     public static final String PARAM_DESCR_EMBEDCERT =
             "For DSIG: the provided certificate is embedded into the signed swidtag; for COSE: the "
                     + "provided certificate and the thumbprint are embedded into protected header.";
-    public static final String PARA_DESCR_EXTRACT = "For PCRIM, print the base RIM contents to a "
-            + "separate file without the XML signature block.";
     public static final String PARAM_DESCR_HELP = "Print this help text.";
     public static final String PARAM_DESCR_IGNOREVALIDATORS =
             "Ignores the validator checks for testing purposes.";

--- a/src/main/java/rimtool/commands/CommandVerify.java
+++ b/src/main/java/rimtool/commands/CommandVerify.java
@@ -22,6 +22,11 @@ public class CommandVerify {
             help = true,
             description = CommandDefinitions.PARAM_DESCR_HELP)
     private boolean help;
+    @Parameter(names = {CommandDefinitions.ARG_EXTRACT_TO_BE_SIGNED_SHORT,
+            CommandDefinitions.ARG_EXTRACT_TO_BE_SIGNED},
+            help = true,
+            description = CommandDefinitions.PARA_DESCR_EXTRACT)
+    private boolean extract = false;
 
     // input files
     @Parameter(names = {CommandDefinitions.ARG_IN_SHORT, CommandDefinitions.ARG_IN},

--- a/src/main/java/rimtool/commands/CommandVerify.java
+++ b/src/main/java/rimtool/commands/CommandVerify.java
@@ -22,11 +22,6 @@ public class CommandVerify {
             help = true,
             description = CommandDefinitions.PARAM_DESCR_HELP)
     private boolean help;
-    @Parameter(names = {CommandDefinitions.ARG_EXTRACT_TO_BE_SIGNED_SHORT,
-            CommandDefinitions.ARG_EXTRACT_TO_BE_SIGNED},
-            help = true,
-            description = CommandDefinitions.PARA_DESCR_EXTRACT)
-    private boolean extract = false;
 
     // input files
     @Parameter(names = {CommandDefinitions.ARG_IN_SHORT, CommandDefinitions.ARG_IN},


### PR DESCRIPTION
These changes allow the `print` function to output PCRIMs in a human-readable format by adding whitespace.

#### Testing ####
1. Build/install from this branch
2. Run: `rim print -r pcrim -i [base_rim]` where [base_rim] is any PCRIM XML document.
3. Confirm that the output is indented and whitespaced in an easy-to-read format.

Closes #44 