### PR TITLE
[#41]: Streamline signing for CoRIM protected header + test both routes

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -4,7 +4,7 @@ RIM-Tool License
 This file contains all the licenses for the dependencies used to create the RIM-Tool project. RIM-Tool is licensed under 
 the Apache 2.0 license.
 
-The following dependencies are also licensed under Apache 2.0: JCommander
+The following dependencies are also licensed under Apache 2.0: JCommander, Authlete
 
 This project also bundles HIRS (https://github.com/nsacyber/HIRS), also licensed under Apache 2.0. The NOTICE file for 
 HIRS can be located at the /hirs path from the RIM-Tool source code.

--- a/build.gradle
+++ b/build.gradle
@@ -72,6 +72,7 @@ dependencyCheck {
     }
 }
 dependencies {
+    implementation libs.authlete.cbor
     implementation libs.bouncycastle
     implementation libs.jcommander
 

--- a/gradle/versions.toml
+++ b/gradle/versions.toml
@@ -1,4 +1,5 @@
 [versions]
+authleteCborVersion = "1.21"
 bouncyCastleVersion = "1.83"
 jcommanderVersion = "3.0"
 lombokVersion = "1.18.42"
@@ -7,6 +8,7 @@ lombokVersion = "1.18.42"
 jupiterVersion = "6.0.3"
 
 [libraries]
+authlete-cbor = { module = "com.authlete:cbor", version.ref = "authleteCborVersion" }
 bouncycastle = { module = "org.bouncycastle:bcmail-jdk18on", version.ref = "bouncyCastleVersion" }
 jcommander = { module = "org.jcommander:jcommander", version.ref = "jcommanderVersion" }
 lombok = { module = "org.projectlombok:lombok", version.ref = "lombokVersion" }

--- a/src/main/java/rimtool/Main.java
+++ b/src/main/java/rimtool/Main.java
@@ -13,6 +13,7 @@ import java.security.PublicKey;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -408,6 +409,7 @@ final class Main {
         X509Certificate cert = null;
         byte[] signedRim = null;
         byte[] kid = null;
+        byte[] toBeSigned = null;
         boolean useUnprotectdKid = false;
         //File payloadFile = new File(inFile);
         DefaultCrypto cryptoSigner = new DefaultCrypto();
@@ -436,8 +438,12 @@ final class Main {
                 kid = cryptoSigner.getKid().getBytes(StandardCharsets.UTF_8);
             }
 
-            byte[] toBeSigned = coseSign.createToBeSigned(alg, kid,
-                    payloadData, cert, useUnprotectdKid, embedded, rimType);
+            if (Objects.equals(rimType, GenericRim.RIMTYPE_CORIM_COMID)) {
+                toBeSigned = coseSign.createToBeSigned(payloadData, CoRimBuilder.createProtectedCorimHeader(alg, Objects.requireNonNull(cert), embedded));
+            } else {
+                toBeSigned = coseSign.createToBeSigned(alg, kid,
+                        payloadData, cert, useUnprotectdKid, embedded, rimType);
+            }
             byte[] signature = cryptoSigner.sign(toBeSigned);
 
             coseSign.addSignature(signature);

--- a/src/test/scripts/corim_comid_tests.sh
+++ b/src/test/scripts/corim_comid_tests.sh
@@ -51,6 +51,19 @@ echo "CoRim TEST 6: Verify a signed CoRIM with an embedded cert"
 eval $rim verify -r corim_comid --in $dataDir/tmp/corim-test-embedded-signed1.cose -e >>/dev/null
 rim_expected_pass_status $? "CoRim TEST 6: CoRim verify (embedded)"
 
+# creating a signed CoRIM with CoMID
+echo "CoRim TEST 7: Create an signed CoRIM (with CoMID) from an input configuration file"
+eval $rim create -r corim_comid -c $dataDir/corim/corim_1.json --out \
+  $dataDir/tmp/corim-test-signed2.cbor -p $dataDir/certs/COMP_OEM1_rim_signer_ecc_512_sha384.pem -k \
+  $dataDir/keys/COMP_OEM1_rim_signer_ecc_512_sha384.key >>/dev/null
+rim_expected_pass_status $? "CoRim TEST 7: CoRim create with CoMID (signed)"
+
+# verify signed CoRIM
+echo "CoRim TEST 8: Verify a signed CoRIM"
+eval $rim verify -r corim_comid --in $dataDir/tmp/corim-test-signed2.cbor \
+  -p $dataDir/certs/COMP_OEM1_rim_signer_ecc_512_sha384.pem >>/dev/null
+rim_expected_pass_status $? "CoRim TEST 8: CoRim verify (signed)"
+
 # TODO: Corim with Coswids
 # TODO: Corim with CoTLs
 


### PR DESCRIPTION
There are 2 typical routes of actions for RIMs in this tool:

1. `Create` (unsigned) > `Sign` > `Verify`
2. `Create` (signed) > `Verify`

Currently for CoRIM, these 2 routes differ greatly and the codeflow is different for `Create` (unsigned) versus `Create` (signed). Specifically, the `Create` (signed) code adds fields to the protected header (i.e. corim-meta-map) which the current IETF spec requires (see [section 4.2.1](https://datatracker.ietf.org/doc/draft-ietf-rats-corim/10/)). **Objects with these additions from the `Create` (signed) route are failing to verify.**

This PR is intended to:
- Unify CoRIM's code for `Create` (unsigned) and `Create` (signed), while maintaining additional fields for CoRIM (i.e. corim-meta-map)
- Add respective tests to the `corim_comid_tests.sh` script to test both routes
- Point to an updated HIRS main branch to use as submodule, now that nsacyber/HIRS#1173 is merged

To test, run `src/test/scripts/corim_comid_tests.sh`, or `run_all_tests.sh` if desired.

Resolves #41 