### PR TITLE
Demo debug

### DIFF
--- a/src/main/java/rimtool/Main.java
+++ b/src/main/java/rimtool/Main.java
@@ -284,7 +284,7 @@ final class Main {
                 switch (rimType) {
                     case GenericRim.RIMTYPE_PCRIM:
                         PcClientRim pcRim = new PcClientRim();
-                        pcRim.create(configFile, eventLog, certPath, keyFile, false, outFile);
+                        pcRim.create(configFile, eventLog, certPath, keyFile, isEmbedded, outFile);
                         break;
                     case GenericRim.RIMTYPE_COSWID:
                         CoswidConfig sconf = new CoswidConfig(configFile);

--- a/src/main/java/rimtool/commands/ValidatorCmdCreate.java
+++ b/src/main/java/rimtool/commands/ValidatorCmdCreate.java
@@ -121,7 +121,7 @@ public class ValidatorCmdCreate implements IParametersValidator {
             Iterator itr = supportRims.iterator();
             while (itr.hasNext()) {
                 JsonObject supportRim = (JsonObject) itr.next();
-                String supportRimName = supportRim.getString(SwidTagConstants.NAME);
+                String supportRimName = supportRim.getString(SwidTagConstants.NAME, "");
                 if (supportRimName.contains(File.separator)) {
                     errorMessage += String.format("Support RIM %s has file separator "
                             + "characters in its name, please remove and retry", supportRimName);


### PR DESCRIPTION
Major changes:

- `-e|--embed-cert` places the signing cert in the generated base RIM
- `rim create` will not throw an error if the JSON config file is missing a `"name": [name]` under the payload file
