### PR TITLE
[#52] Implement -a|--algorithm for SHA256, 384, 512

### DIFF
--- a/src/main/java/rimtool/Main.java
+++ b/src/main/java/rimtool/Main.java
@@ -284,7 +284,7 @@ final class Main {
                 switch (rimType) {
                     case GenericRim.RIMTYPE_PCRIM:
                         PcClientRim pcRim = new PcClientRim();
-                        pcRim.create(configFile, eventLog, certPath, keyFile, false, outFile);
+                        pcRim.create(configFile, eventLog, algorithm, certPath, keyFile, false, outFile);
                         break;
                     case GenericRim.RIMTYPE_COSWID:
                         CoswidConfig sconf = new CoswidConfig(configFile);
@@ -322,7 +322,7 @@ final class Main {
                 switch (rimType) {
                     case GenericRim.RIMTYPE_PCRIM:
                         PcClientRim pcRim = new PcClientRim();
-                        pcRim.create(configFile, eventLog, certPath, keyFile, false, outFile);
+                        pcRim.create(configFile, eventLog, algorithm, certPath, keyFile, false, outFile);
                         break;
                     case GenericRim.RIMTYPE_COSWID:
                         CoswidConfig sconf = new CoswidConfig(configFile);

--- a/src/main/java/rimtool/commands/CommandCreate.java
+++ b/src/main/java/rimtool/commands/CommandCreate.java
@@ -46,7 +46,7 @@ public class CommandCreate {
     private String publicCertificate = "";
     @Parameter(names = {CommandDefinitions.ARG_ALGORITHM_SHORT, CommandDefinitions.ARG_ALGORITHM},
             description = CommandDefinitions.PARAM_DESCR_ALGORITHM)
-    private String algorithm = "";
+    private String algorithm = "SHA256"; //Default to SHA256 if omitted
     @Parameter(names = {CommandDefinitions.ARG_DETACHED_SHORT, CommandDefinitions.ARG_DETACHED},
             //validateWith = ValidatorArgFile.class,
             description = CommandDefinitions.PARAM_DESCR_DETACHED)


### PR DESCRIPTION
These changes allow a user to specify `-a|--algorithm SHA(256|384|512)` to create a base RIM with the appropriate hash attribute under `<File>`.  Note: the JSON config file _must not_ have a hash field defined, as in `rim_fields_dynamic_filehash.json` from #54. 

### Testing ###

1. `cd data/pcrim/`
1. `rim create -r pcrim -c rim_fields_dynamic_filehash.json -k rimKey.pem -p RimSignCert.pem -l TpmLog.bin \ -a SHA256 -o test_SHA256.swidtag`
2. `xmlsec1 --verify test_SHA256.swidtag`
3. Confirm that test_SHA256.swidtag contains `SHA256:hash="4479ca722623f8c47b703996ced3cbd981b06b1ae8a897db70137e0b7c546848"`
4. `rim create -r pcrim -c rim_fields_dynamic_filehash.json -k rimKey.pem -p RimSignCert.pem -l TpmLog.bin \ -a SHA384 -o test_SHA384.swidtag`
5. `xmlsec1 --verify test_SHA384.swidtag`
6. Confirm that test_SHA384.swidtag contains `SHA384:hash="75850e7cc6631dcec8a44e5da48ddd1ef5b73ba4e2c386c0d34950fc9acb4acef4af66b3d761412ce24773906a10af62"`
7. `rim create -r pcrim -c rim_fields_dynamic_filehash.json -k rimKey.pem -p RimSignCert.pem -l TpmLog.bin \ -a SHA512 -o test_SHA512.swidtag`
8. `xmlsec1 --verify test_SHA512.swidtag`
9. Confirm that test_SHA512.swidtag contains `SHA512:hash="99908b63303d99931729835661bded8f7d7a1bad17e7d51d4b0896cb8164e40b81f148a183c05a7ad4d918ff815fd630e837b23c2547f68cd257da4441b19f7b"`